### PR TITLE
Add configurable API secret key setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Only administrators have access to this page, where they can manually generate t
 Course tokens can be generated securely via an API, which requires a valid secret key for authentication. This ensures that only authorized users can create tokens. By using a unique secret key, we protect the process from unauthorized access, making this solution more secure than traditional methods. This approach ensures both flexibility and enhanced security for administrators when managing token creation programmatically.
 
 **Required parameters:**
-1. `secret_key`: string ([Here is how to generate one](#how-to-generate-a-secret-key))
+1. `secret_key`: string (set this in Site administration > Plugins > Enrolments > Course tokens > API secret key)
 2. `course_id`: integer (The ID of the course for which tokens are being created.)
 3. `email`: string (Email address of the user)
 4. `quantity`: integer (Number of tokens)
@@ -62,7 +62,7 @@ Course tokens can be generated securely via an API, which requires a valid secre
 curl 'https://learn.pacificmedicaltraining.com/enrol/course_tokens/api-do-create-token.php' \
   --header "Content-Type: application/json" \
   --data-bs-raw '{
-    "secret_key": "secret_key",
+      "secret_key": "your-api-secret-key",
     "course_id": 5,
     "email": "minicurl@example.com",
     "quantity": 1,
@@ -83,7 +83,7 @@ curl 'https://learn.pacificmedicaltraining.com/enrol/course_tokens/api-do-create
 curl 'https://learn.pacificmedicaltraining.com/enrol/course_tokens/api-do-create-token.php' \
   --header "Content-Type: application/json" \
   --data-bs-raw '{
-    "secret_key": "secret_key",
+      "secret_key": "your-api-secret-key",
     "course_id": 5,
     "email": "minicurl@example.com",
     "quantity": 1,
@@ -110,31 +110,11 @@ Manual token creation from the Moodle UI still records the currently logged-in u
 
 ### How to generate a secret key
 
-Follow these steps to generate a secure secret_key for your plugin:
-1. Create a file named `key.php` in the `course_tokens` directory.
-2. Add the following code to `key.php`:
+Set the value in `Site administration > Plugins > Enrolments > Course tokens > API secret key`.
 
-```php
-<?php
-require_once('../../config.php');
-require_login();
-require_capability('moodle/site:config', context_system::instance());
+The API request sends the key using the JSON field `secret_key`.
 
-// Set the secret key for the plugin
-$plugin_name = 'course_token'; // Replace with your plugin's name
-$secret_key = bin2hex(random_bytes(16)); // Generate a secure random key
-set_config('secretkey', $secret_key, $plugin_name);
-
-echo "Secret key for plugin '{$plugin_name}' has been set to: {$secret_key}";
-```
-
-3. Run the `key.php` file by accessing it in your browser or command line.
-
-Example:
-
-`https://yourmoodlesite.com/enrol/course_tokens/key.php`
-
-4. The `secret_key` will be displayed on your screen. Save it securely, as it will be required for all API requests.
+If you rotate the key, update any external API clients to send the new value in the existing `secret_key` JSON field.
 
 ### View tokens
 

--- a/api-do-create-token.php
+++ b/api-do-create-token.php
@@ -140,7 +140,17 @@ if (!empty($json_input)) {
 // Retrieve secret key from Moodle's configuration with retry
 try {
   $valid_secret_key = retry_operation(function() {
-    $key = get_config('course_tokens', 'secretkey');
+    $key = get_config('enrol_course_tokens', 'secretkey');
+
+    if (empty($key)) {
+      $legacykey = get_config('course_tokens', 'secretkey');
+
+      if (!empty($legacykey)) {
+        $key = $legacykey;
+        set_config('secretkey', $legacykey, 'enrol_course_tokens');
+      }
+    }
+
     if (empty($key)) {
       throw new Exception("Secret key not found in config");
     }
@@ -148,7 +158,7 @@ try {
   }, MAX_RETRIES, RETRY_DELAY_MS, "Secret key retrieval");
 } catch (Exception $e) {
   http_response_code(500);
-  echo json_encode(['error' => 'Configuration error. Please try again later.']);
+  echo json_encode(['error' => get_string('missingsecretkey', 'enrol_course_tokens')]);
   exit;
 }
 

--- a/lang/en/enrol_course_tokens.php
+++ b/lang/en/enrol_course_tokens.php
@@ -70,6 +70,10 @@ $string['tokencreatoruserid_desc'] = 'Enter the Moodle user ID to record as the 
 $string['error_missing_token_creator_user'] = 'Automated token creation is not configured. Please ask a site administrator to configure the automated token creator user ID in the Course tokens enrolment settings.';
 $string['error_invalid_token_creator_user'] = 'The configured automated token creator user is invalid, deleted, suspended, or cannot be used.';
 
+$string['secretkey'] = 'API secret key';
+$string['secretkey_desc'] = 'Secret key required by the course token creation API. Treat this like a password and rotate it if it may have been exposed.';
+$string['missingsecretkey'] = 'The course token API secret key has not been configured.';
+
 $string['customer_group_field'] = 'Corporate Group Profile Field';
 $string['customer_group_field_desc'] = 'Select the custom user profile field used to store the corporate/group account name. This maps the token order group name to a specific user field. If "None" is selected, group mapping is disabled.';
 

--- a/settings.php
+++ b/settings.php
@@ -80,6 +80,15 @@ if ($hassiteconfig) {
             PARAM_INT
         ));
 
+        // 5b. API Secret Key
+        $settings->add(new admin_setting_configtext(
+            'enrol_course_tokens/secretkey',
+            new lang_string('secretkey', 'enrol_course_tokens'),
+            new lang_string('secretkey_desc', 'enrol_course_tokens'),
+            '',
+            PARAM_RAW_TRIMMED
+        ));
+
         // 6. Corporate/Group Profile Field Mapping
         $settings->add(new admin_setting_configselect(
             'enrol_course_tokens/customer_group_field',


### PR DESCRIPTION
## Update: API secret key configuration moved to proper Moodle plugin settings [#443](https://github.com/modern-training-solutions/learn.PacificMedicalTraining.com/issues/443)

This PR fixes the API secret key configuration issue for `enrol_course_tokens`.

### Problem

The API token creation endpoint was reading the API secret key from:

```php
get_config('course_tokens', 'secretkey')
```

This was not ideal for two reasons.

First, `course_tokens` is not the correct Moodle plugin component name. The plugin component is:

```text
enrol_course_tokens
```

Second, there was no proper admin setting in `settings.php` for managing the API secret key. This meant a site administrator could not easily set or rotate the API key through the Moodle UI.

The previous README also suggested creating a temporary `key.php` file to set the secret. That approach works, but it is not ideal because it requires manual code/file handling and could become risky if the temporary file is accidentally left on the server.

### What changed

The API secret key is now managed through the Course tokens plugin settings page.

New setting:

```text
Site administration > Plugins > Enrolments > Course tokens > API secret key
```

The setting stores the value under the correct Moodle component:

```text
enrol_course_tokens / secretkey
```

The API request format did not change. API clients still send the key using the same JSON field:

```json
{
  "secret_key": "your-api-secret-key"
}
```

### Files changed

```text
README.md
api-do-create-token.php
lang/en/enrol_course_tokens.php
settings.php
```

### API behavior before

Previously, the API checked the secret key using:

```php
get_config('course_tokens', 'secretkey')
```

This meant the key was stored under an inconsistent/legacy config component and could not be managed from the plugin settings UI.

### API behavior after

The API now checks the secret key from the correct component first:

```php
get_config('enrol_course_tokens', 'secretkey')
```

For backward compatibility, it also checks the old legacy location if the new setting is empty:

```php
get_config('course_tokens', 'secretkey')
```

If a legacy key is found, the code uses it and copies it forward into the correct component:

```php
set_config('secretkey', $legacykey, 'enrol_course_tokens')
```

The old config value is not deleted. This avoids breaking existing installations that may already have the API key stored under the legacy component.

### Why legacy fallback was kept

The fallback was kept to avoid breaking existing production API integrations during deployment.

For PMT/live usage, this means the API continues to work even if the key was previously stored under:

```text
course_tokens / secretkey
```

Once the plugin setting is saved in Moodle admin, the clean/current value lives under:

```text
enrol_course_tokens / secretkey
```

This gives us a safe migration path without changing the API payload or disrupting existing token creation.

### What did not change

This PR does not change:

```text
API endpoint URL
API JSON field name secret_key
token creation behavior
user creation behavior
enrolment behavior
email behavior
created_by behavior
token dashboard behavior
manual token creation behavior
```

The API remains backward-compatible from the client side. External systems do not need to rename the `secret_key` field.

### Security note

The actual API secret key is not hardcoded in the plugin code.

The code only references the Moodle config key name:

```php
get_config('enrol_course_tokens', 'secretkey')
```

The actual secret value is stored in Moodle configuration and can now be set or rotated from the admin UI.

This is safer than using a temporary PHP script to generate or set the key.

### README update

The README was updated to remove the old `key.php` setup instructions and replace them with the Moodle admin setting approach.

The documentation now tells administrators to configure the key here:

```text
Site administration > Plugins > Enrolments > Course tokens > API secret key
```

It also clarifies that API requests still send the key using the JSON field:

```text
secret_key
```

### Testing performed

Local testing was completed successfully.

Tested on local Moodle:

```text
http://192.168.64.6/
```

The following cases were tested:

1. A new API secret key was generated locally.
2. The key was saved in the new Moodle admin setting.
3. API request with the correct key succeeded and created a token.
4. API request with a wrong key failed with unauthorized response.
5. Token creation still worked normally when the correct key was used.
6. The API request format remained unchanged.

Example local API request used for testing:

```bash
curl -i 'http://192.168.64.6/enrol/course_tokens/api-do-create-token.php' \
  -H 'Content-Type: application/json' \
  --data-raw '{
    "secret_key": "LOCAL_TEST_KEY",
    "course_id": 5,
    "email": "api-secret-test-001@example.com",
    "quantity": 1,
    "firstname": "API",
    "lastname": "SecretTest",
    "group_account": "Local Test",
    "extra_json": {
      "order_number": 442001,
      "test_note": "API secret setting test"
    }
  }'
```

Wrong-key test also passed: the API rejected the request and did not create a token.

### Deployment note

After deploying this change, confirm the live API secret key is set here:

```text
Site administration > Plugins > Enrolments > Course tokens > API secret key
```

If the old key exists under the legacy component, the fallback should preserve functionality and copy it forward. However, the clean final state is to save the key through the Moodle admin setting so it is stored under:

```text
enrol_course_tokens / secretkey
```

### Final result

The API secret key is now configurable, rotatable from Moodle admin UI, stored under the correct plugin component, and still backward-compatible with the previous legacy config location.
